### PR TITLE
Add translation bot config that disables sync PRs

### DIFF
--- a/translation-bot.json
+++ b/translation-bot.json
@@ -1,0 +1,3 @@
+{
+    "disabled": true
+}


### PR DESCRIPTION
This PR adds a small config file for the bot, which will make it stop submitting daily sync PRs (see [Bot configuration](https://github.com/solidity-docs/translation-guide#bot-configuration)).

Since you're targeting 0.8.15, the bot is currently hard-coded to skip this repository. When you merge the PR, I will be able to change that, letting you control the bot yourself.