### PR TITLE
Fix sphinx-a4doc version to 1.3.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,7 +4,7 @@
 sphinx_rtd_theme>=0.5.2
 
 pygments-lexer-solidity>=0.7.0
-sphinx-a4doc>=1.2.1
+sphinx-a4doc==1.3.0
 
 # Sphinx 2.1.0 is the oldest version that accepts a lexer class in add_lexer()
 sphinx>=2.1.0


### PR DESCRIPTION
A workaround for the breaking changes in `sphinx-a4doc` version [1.4.0](https://github.com/taminomara/sphinx-a4doc/commit/169ca4384e095e752b34bdf95b9f7c151e9e5abb), which make diagrams build crash due to `unknown node type: RailroadDiagramNode`.